### PR TITLE
Add webproxy support to RequestFactoryExtensions

### DIFF
--- a/OAuth2/Infrastructure/RequestFactoryExtensions.cs
+++ b/OAuth2/Infrastructure/RequestFactoryExtensions.cs
@@ -1,5 +1,6 @@
-﻿using OAuth2.Client;
+using OAuth2.Client;
 using RestSharp;
+using System.Net;
 
 namespace OAuth2.Infrastructure
 {
@@ -9,6 +10,9 @@ namespace OAuth2.Infrastructure
         {
             var client = factory.CreateClient();
             client.BaseUrl = endpoint.BaseUri;
+            IWebProxy webProxy = WebRequest.DefaultWebProxy;
+            webProxy.Credentials = CredentialCache.DefaultNetworkCredentials;
+            client.Proxy = webProxy;
             return client;
         }
 


### PR DESCRIPTION
Add proxy server to IRestClient.proxy from default system settings. 
Tested in Windows 8 with proxy server as a development environment, and Debian/Mono as a production. 
