### PR TITLE
adds method for explicitly retrieving the access token,

### DIFF
--- a/OAuth2/Client/OAuth2Client.cs
+++ b/OAuth2/Client/OAuth2Client.cs
@@ -77,17 +77,20 @@ namespace OAuth2.Client
         /// <param name="parameters">Callback request payload (parameters).</param>
         public UserInfo GetUserInfo(NameValueCollection parameters)
         {
-            const string errorFieldName = "error";
-            var error = parameters[errorFieldName];
-            if (!error.IsEmpty())
-            {
-                throw new UnexpectedResponseException(errorFieldName);
-            }
-
-            State = parameters["state"];
-
+            CheckErrorAndSetState(parameters);
             QueryAccessToken(parameters);
             return GetUserInfo();
+        }
+
+        /// <summary>
+        /// Issues query for access token and returns access token.
+        /// </summary>
+        /// <param name="parameters">Callback request payload (parameters).</param>
+        public string GetToken(NameValueCollection parameters)
+        {
+            CheckErrorAndSetState(parameters);
+            QueryAccessToken(parameters);
+            return AccessToken;
         }
 
         /// <summary>
@@ -105,6 +108,18 @@ namespace OAuth2.Client
         /// who is currently logged in.
         /// </summary>
         protected abstract Endpoint UserInfoServiceEndpoint { get; }
+
+        private void CheckErrorAndSetState(NameValueCollection parameters)
+        {
+            const string errorFieldName = "error";
+            var error = parameters[errorFieldName];
+            if (!error.IsEmpty())
+            {
+                throw new UnexpectedResponseException(errorFieldName);
+            }
+
+            State = parameters["state"];
+        }
 
         /// <summary>
         /// Issues query for access token and parses response.


### PR DESCRIPTION
The current implementation hides the QueryAccessToken method and only allows to get the access token via the GetUserInfo method.

Furthermore, the google client _requires_ access to the 
https://www.googleapis.com/auth/userinfo.profile and https://www.googleapis.com/auth/userinfo.email scopes for successfully calling GetUserInfo w/o getting an exception. I believe that's asking for too many permissions that might not bee needed by the client.

Hence the GetToken provides an explicit way to retrieve the access token.

Other than that, the library is a pleasure to work with, kudos!
