### PR TITLE
Implemented safeget method for email retrieval for some clients

### DIFF
--- a/OAuth2/Client/Impl/FacebookClient.cs
+++ b/OAuth2/Client/Impl/FacebookClient.cs
@@ -88,7 +88,7 @@ namespace OAuth2.Client.Impl
                 Id = response["id"].Value<string>(),
                 FirstName = response["first_name"].Value<string>(),
                 LastName = response["last_name"].Value<string>(),
-                Email = response["email"].Value<string>(),
+                Email = response["email"].SafeGet(x => x.Value<string>()),
                 AvatarUri =
                 {
                     Small = !string.IsNullOrWhiteSpace(avatarUri) ? string.Format(avatarUriTemplate, avatarUri, "small") : string.Empty,

--- a/OAuth2/Client/Impl/FoursquareClient.cs
+++ b/OAuth2/Client/Impl/FoursquareClient.cs
@@ -95,7 +95,7 @@ namespace OAuth2.Client.Impl
                 Id = response["response"]["user"]["id"].Value<string>(),
                 FirstName = response["response"]["user"]["firstName"].Value<string>(),
                 LastName = response["response"]["user"]["lastName"].Value<string>(),
-                Email = response["response"]["user"]["contact"]["email"].Value<string>(),                
+                Email = response["response"]["user"]["contact"]["email"].SafeGet(x => x.Value<string>()),                
                 AvatarUri =
                 {
                     // Defined photo sizes https://developer.foursquare.com/docs/responses/photo

--- a/OAuth2/Client/Impl/GitHubClient.cs
+++ b/OAuth2/Client/Impl/GitHubClient.cs
@@ -41,7 +41,7 @@ namespace OAuth2.Client.Impl
             var avatarUri = cnt["avatar_url"].Value<string>();
             var result = new UserInfo
                 {
-                    Email = cnt["email"].Value<string>(),
+                    Email = cnt["email"].SafeGet(x => x.Value<string>()),
                     ProviderName = this.Name,
                     Id = cnt["id"].Value<string>(),
                     FirstName = names.Count > 0 ? names.First() : cnt["login"].Value<string>(),

--- a/OAuth2/Client/Impl/GoogleClient.cs
+++ b/OAuth2/Client/Impl/GoogleClient.cs
@@ -86,7 +86,7 @@ namespace OAuth2.Client.Impl
             return new UserInfo
             {
                 Id = response["id"].Value<string>(),
-                Email = response["email"].Value<string>(),
+                Email = response["email"].SafeGet(x => x.Value<string>()),
                 FirstName = response["given_name"].Value<string>(),
                 LastName = response["family_name"].Value<string>(),
                 AvatarUri =

--- a/OAuth2/Client/Impl/MailRuClient.cs
+++ b/OAuth2/Client/Impl/MailRuClient.cs
@@ -110,7 +110,7 @@ namespace OAuth2.Client.Impl
                 Id = response[0]["uid"].Value<string>(),
                 FirstName = response[0]["first_name"].Value<string>(),
                 LastName = response[0]["last_name"].Value<string>(),
-                Email = response[0]["email"].Value<string>(),
+                Email = response[0]["email"].SafeGet(x => x.Value<string>()),
                 AvatarUri =
                     {
                         Small = null,

--- a/OAuth2/Client/Impl/WindowsLiveClient.cs
+++ b/OAuth2/Client/Impl/WindowsLiveClient.cs
@@ -88,7 +88,7 @@ namespace OAuth2.Client.Impl
                 Id = response["id"].Value<string>(),
                 FirstName = response["first_name"].Value<string>(),
                 LastName = response["last_name"].Value<string>(),
-                Email = response["emails"]["preferred"].Value<string>(),
+                Email = response["emails"]["preferred"].SafeGet(x => x.Value<string>()),
                 AvatarUri =
                     {
                         Small = string.Format(avatarUriTemplate, response["id"].Value<string>(), "UserTileSmall"),

--- a/OAuth2/Client/Impl/YandexClient.cs
+++ b/OAuth2/Client/Impl/YandexClient.cs
@@ -90,7 +90,7 @@ namespace OAuth2.Client.Impl
                 Id = response["id"].Value<string>(),
                 FirstName = names.Any() ? names.First() : response["display_name"].Value<string>(),
                 LastName = names.Count() > 1 ? names.Last() : string.Empty,
-                Email = response["default_email"].Value<string>(),
+                Email = response["default_email"].SafeGet(x => x.Value<string>()),
             };
         }
 


### PR DESCRIPTION
Hi Constantin,

I recently came across a problem - the code was throwing an exception when my requests did not ask for the email address of a user, only a basic profile (I did not care about it and did not want to ask more than I needed). 

I went and changed the code to use SafeGet method to just save null if the response does not contain email.

P.S. This project is awesome and saved me a ton of time

Thank you

Roman Tumaykin
