### PR TITLE
Added the ability to get private email addresses

### DIFF
--- a/OAuth2/Client/Impl/GitHubClient.cs
+++ b/OAuth2/Client/Impl/GitHubClient.cs
@@ -84,7 +84,7 @@ namespace OAuth2.Client.Impl
 
             var response = client.ExecuteAndVerify(request);
             var userEmails = ParseEmailAddresses(response.Content);
-            userInfo.Email = userEmails.First(u => u.Primary).Email;
+            userInfo.Email = userEmails.First(u => u.IsPrimary).Email;
             return userInfo;
         }
 
@@ -133,8 +133,8 @@ namespace OAuth2.Client.Impl
         protected class UserEmails
         {
             public string Email { get; set; }
-            public bool Primary { get; set; }
-            public bool Verified { get; set; }
+            public bool IsPrimary { get; set; }
+            public bool IsVerified { get; set; }
         }
     }
 }


### PR DESCRIPTION
A large percentage of github users don't have public email addresses.
Therefore, you need to request the scope: user:email or user to get the
email addresses. The issue is that the initial userinfo request doesn't
contain the private email addresses. This needs to be done in a separate
request
(https://developer.github.com/v3/users/emails/#list-email-addresses-for-a-user).

This code makes that separate request and grabs the first verified user.