### PR TITLE
Issue/67 Allows discovery of custom client types in other assemblies

### DIFF
--- a/OAuth2/AuthorizationRoot.cs
+++ b/OAuth2/AuthorizationRoot.cs
@@ -69,7 +69,8 @@ namespace OAuth2
         /// </summary>        
         protected virtual IEnumerable<Type> GetClientTypes()
         {
-            return Assembly.GetExecutingAssembly().GetTypes().Where(typeof (IClient).IsAssignableFrom);
+          var clientType = typeof(IClient);
+          return AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes()).Where(p => clientType.IsAssignableFrom(p));
         }
     }
 }

--- a/OAuth2/AuthorizationRoot.cs
+++ b/OAuth2/AuthorizationRoot.cs
@@ -69,8 +69,7 @@ namespace OAuth2
         /// </summary>        
         protected virtual IEnumerable<Type> GetClientTypes()
         {
-          var clientType = typeof(IClient);
-          return AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes()).Where(p => clientType.IsAssignableFrom(p));
+          return AppDomain.CurrentDomain.GetAssemblies().SelectMany(s => s.GetTypes()).Where(p => typeof(IClient).IsAssignableFrom(p));
         }
     }
 }


### PR DESCRIPTION
Currently it is not possible to add your own custom clients from your own assembly. This means that unless it is an existing client native to this project you have to create a custom build of the project. I've forked the project and made a small change to allow discovery of clients in other assemblies.

Thanks, Simon