### PR TITLE
Added IOAuthConfigurationSection

### DIFF
--- a/OAuth2/AuthorizationRoot.cs
+++ b/OAuth2/AuthorizationRoot.cs
@@ -11,7 +11,7 @@ namespace OAuth2
     public class AuthorizationRoot
     {
         private readonly IRequestFactory _requestFactory;
-        private readonly OAuth2ConfigurationSection _configurationSection;
+        private readonly IOAuth2ConfigurationSection _configurationSection;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizationRoot" /> class.
@@ -40,7 +40,7 @@ namespace OAuth2
         {
             _requestFactory = requestFactory;
             _configurationSection = configurationManager
-                .GetConfigSection<OAuth2ConfigurationSection>(configurationSectionName);
+                .GetConfigSection<IOAuth2ConfigurationSection>(configurationSectionName);
         }
         
         /// <summary>

--- a/OAuth2/Client/Impl/WindowsLiveClient.cs
+++ b/OAuth2/Client/Impl/WindowsLiveClient.cs
@@ -82,12 +82,11 @@ namespace OAuth2.Client.Impl
         {
             var response = JObject.Parse(content);
             const string avatarUriTemplate = @"https://cid-{0}.users.storage.live.com/users/0x{0}/myprofile/expressionprofile/profilephoto:Win8Static,{1},UserTileStatic/MeControlXXLUserTile?ck=2&ex=24";
-            return new UserInfo
+            var userinfo =  new UserInfo
             {
                 Id = response["id"].Value<string>(),
                 FirstName = response["first_name"].Value<string>(),
                 LastName = response["last_name"].Value<string>(),
-                Email = response["emails"]["preferred"].SafeGet(x => x.Value<string>()),
                 AvatarUri =
                     {
                         Small = string.Format(avatarUriTemplate, response["id"].Value<string>(), "UserTileSmall"),
@@ -95,6 +94,13 @@ namespace OAuth2.Client.Impl
                         Large = string.Format(avatarUriTemplate, response["id"].Value<string>(), "UserTileLarge")
                     }
             };
+
+            if (Configuration.Scope.ToUpperInvariant().Contains("WL.EMAILS"))
+            {
+                userinfo.Email = response["emails"]["preferred"].SafeGet(x => x.Value<string>());
+            } // if
+
+            return userinfo;
         }
 
         public override string Name

--- a/OAuth2/Configuration/IOAuth2ConfigurationSection.cs
+++ b/OAuth2/Configuration/IOAuth2ConfigurationSection.cs
@@ -1,0 +1,18 @@
+namespace OAuth2.Configuration
+{
+    /// <summary>
+    /// Library configuration section handler.
+    /// </summary>
+    public interface IOAuth2ConfigurationSection
+    {
+        /// <summary>
+        /// Returns settings for service client with given name.
+        /// </summary>
+        IClientConfiguration this[string clientTypeName] { get; }
+
+        /// <summary>
+        /// Gets the services.
+        /// </summary>
+        ServiceCollection Services { get; }
+    }
+}

--- a/OAuth2/Configuration/OAuth2ConfigurationSection.cs
+++ b/OAuth2/Configuration/OAuth2ConfigurationSection.cs
@@ -5,7 +5,7 @@ namespace OAuth2.Configuration
     /// <summary>
     /// Library configuration section handler.
     /// </summary>
-    public class OAuth2ConfigurationSection : ConfigurationSection, IOAuth2Configuration
+    public class OAuth2ConfigurationSection : ConfigurationSection, IOAuth2ConfigurationSection, IOAuth2Configuration
     {
         private const string CollectionName = "services";
 

--- a/OAuth2/OAuth2.csproj
+++ b/OAuth2/OAuth2.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Configuration\IConfigurationManager.cs" />
     <Compile Include="Configuration\IOAuth2Configuration.cs" />
     <Compile Include="Configuration\IClientConfiguration.cs" />
+    <Compile Include="Configuration\IOAuth2ConfigurationSection.cs" />
     <Compile Include="Configuration\OAuth2ConfigurationSection.cs" />
     <Compile Include="Configuration\ClientConfiguration.cs" />
     <Compile Include="Configuration\RuntimeClientConfiguration.cs" />


### PR DESCRIPTION
While it is good in many case to have the client information stored in a configuration file, it is not so godd for my use case. I have a standalone tool that will be used on different machines by different users. They should not see or even change the clinet configuration.
In order to create an IConfigurationManager that suits meed needs I added an IOAuth2ConfigurationSection interface.