### PR TITLE
Async support

### DIFF
--- a/OAuth2.Tests/Client/Impl/FacebookClientTests.cs
+++ b/OAuth2.Tests/Client/Impl/FacebookClientTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Specialized;
 using System.Net;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -76,7 +77,7 @@ namespace OAuth2.Tests.Client.Impl
         }
 
         [Test]
-        public void Should_AddExtraParameters_WhenOnGetUserInfoIsCalled()
+        public async Task Should_AddExtraParameters_WhenOnGetUserInfoIsCalled()
         {
             // arrange
             requestFactory.CreateClient().Execute(requestFactory.CreateRequest())
@@ -86,7 +87,7 @@ namespace OAuth2.Tests.Client.Impl
                     content);
 
             // act
-            descendant.GetUserInfo(new NameValueCollection
+            await descendant.GetUserInfoAsync(new NameValueCollection
             {
                 {"code", "code"}
             });

--- a/OAuth2.Tests/Client/Impl/VkClientTests.cs
+++ b/OAuth2.Tests/Client/Impl/VkClientTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using System.Net;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
@@ -75,7 +76,7 @@ namespace OAuth2.Tests.Client.Impl
         }
 
         [Test]
-        public void Should_ReceiveUserId_WhenAccessTokenResponseReceived()
+        public async Task Should_ReceiveUserId_WhenAccessTokenResponseReceived()
         {
             // arrange
             var response = factory.CreateClient().Execute(factory.CreateRequest());
@@ -86,7 +87,7 @@ namespace OAuth2.Tests.Client.Impl
                 content);
 
             // act
-            descendant.GetUserInfo(new NameValueCollection
+            await descendant.GetUserInfoAsync(new NameValueCollection
             {
                 {"code", "code"}
             });
@@ -96,7 +97,7 @@ namespace OAuth2.Tests.Client.Impl
         }
 
         [Test]
-        public void Should_AddExtraParameters_WhenOnGetUserInfoIsCalled()
+        public async Task Should_AddExtraParameters_WhenOnGetUserInfoIsCalled()
         {
             // arrange
             var restClient = factory.CreateClient();
@@ -108,7 +109,7 @@ namespace OAuth2.Tests.Client.Impl
                 content);
 
             // act
-            descendant.GetUserInfo(new NameValueCollection
+            await descendant.GetUserInfoAsync(new NameValueCollection
             {
                 {"code", "code"}
             });

--- a/OAuth2.Tests/Client/OAuth2ClientTests.cs
+++ b/OAuth2.Tests/Client/OAuth2ClientTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.Net;
+using System.Threading.Tasks;
 using FizzWare.NBuilder;
 using NSubstitute;
 using NUnit.Framework;
@@ -56,7 +57,7 @@ namespace OAuth2.Tests.Client
             restResponse.StatusCode = HttpStatusCode.InternalServerError;
 
             descendant
-                .Invoking(x => x.GetUserInfo(new NameValueCollection()))
+                .Awaiting(x => x.GetUserInfoAsync(new NameValueCollection()))
                 .ShouldThrow<UnexpectedResponseException>();
         }
 
@@ -67,7 +68,7 @@ namespace OAuth2.Tests.Client
             restResponse.Content.Returns("");
             
             descendant
-                .Invoking(x => x.GetUserInfo(new NameValueCollection()))
+                .Awaiting(x => x.GetUserInfoAsync(new NameValueCollection()))
                 .ShouldThrow<UnexpectedResponseException>();
         }
 
@@ -78,7 +79,7 @@ namespace OAuth2.Tests.Client
             restClient.BuildUri(restRequest).Returns(new Uri("https://login-link.net/"));
 
             // act
-            var uri = descendant.GetLoginLinkUri();
+            var uri = descendant.GetLoginLinkUriAsync();
 
             // assert
             uri.Should().Be("https://login-link.net/");
@@ -111,7 +112,7 @@ namespace OAuth2.Tests.Client
 
             // act & assert
             descendant
-                .Invoking(x => x.GetUserInfo(parameters))
+                .Awaiting(x => x.GetUserInfoAsync(parameters))
                 .ShouldThrow<UnexpectedResponseException>()
                 .And.FieldName.Should().Be("error");
         }
@@ -126,7 +127,7 @@ namespace OAuth2.Tests.Client
 
             // act & assert
             descendant
-                .Invoking(x => x.GetUserInfo(new NameValueCollection
+                .Awaiting(x => x.GetUserInfoAsync(new NameValueCollection
                 {
                     {"error", error},
                     {"code", "code"}
@@ -135,13 +136,13 @@ namespace OAuth2.Tests.Client
         }
 
         [Test]
-        public void Should_IssueCorrectRequestForAccessToken_When_GetUserInfoIsCalled()
+        public async Task Should_IssueCorrectRequestForAccessToken_When_GetUserInfoIsCalled()
         {
             // arrange
             restResponse.Content = "access_token=token";
 
             // act
-            descendant.GetUserInfo(new NameValueCollection {{"code", "code"}});
+            await descendant.GetUserInfoAsync(new NameValueCollection {{"code", "code"}});
 
             // assert
             restClient.Received(1).BaseUrl = new Uri("https://AccessTokenServiceEndpoint");
@@ -161,13 +162,13 @@ namespace OAuth2.Tests.Client
         [Test]
         [TestCase("access_token=token")]
         [TestCase("{\"access_token\": \"token\"}")]
-        public void Should_IssueCorrectRequestForUserInfo_When_GetUserInfoIsCalled(string response)
+        public async Task Should_IssueCorrectRequestForUserInfo_When_GetUserInfoIsCalled(string response)
         {
             // arrange
             restResponse.Content.Returns(response);
 
             // act
-            descendant.GetUserInfo(new NameValueCollection {{"code", "code"}});
+            await descendant.GetUserInfoAsync(new NameValueCollection { { "code", "code" } });
 
             // assert
             restClient.Received(1).BaseUrl = new Uri("https://UserInfoServiceEndpoint");

--- a/OAuth2.Tests/Client/OAuth2ClientTests.cs
+++ b/OAuth2.Tests/Client/OAuth2ClientTests.cs
@@ -73,13 +73,13 @@ namespace OAuth2.Tests.Client
         }
 
         [Test]
-        public void Should_ReturnCorrectAccessCodeRequestUri()
+        public async Task Should_ReturnCorrectAccessCodeRequestUri()
         {
             // arrange
             restClient.BuildUri(restRequest).Returns(new Uri("https://login-link.net/"));
 
             // act
-            var uri = descendant.GetLoginLinkUriAsync();
+            var uri = await descendant.GetLoginLinkUriAsync();
 
             // assert
             uri.Should().Be("https://login-link.net/");

--- a/OAuth2.Tests/Infrastructure/SafeExtensionsTests.cs
+++ b/OAuth2.Tests/Infrastructure/SafeExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using OAuth2.Client;
 using OAuth2.Infrastructure;
@@ -10,12 +11,12 @@ namespace OAuth2.Tests.Infrastructure
     public class SafeExtensionsTests
     {
         [Test]
-        public void Should_NotThrow_WhenSafeGetIsCalledOnNull()
+        public async Task Should_NotThrow_WhenSafeGetIsCalledOnNull()
         {
             // act & assert
-            ((IClient)null).Invoking(x => x.SafeGet(z => z.GetLoginLinkUri()))
+            ((IClient)null).Awaiting(x => x.SafeGetAsync(z => z.GetLoginLinkUriAsync()))
                 .ShouldNotThrow<NullReferenceException>();
-            ((IClient)null).SafeGet(x => x.GetLoginLinkUri()).Should().Be(null);
+            (await ((IClient)null).SafeGetAsync(x => x.GetLoginLinkUriAsync())).Should().Be(null);
         }
 
         [Test]
@@ -23,10 +24,10 @@ namespace OAuth2.Tests.Infrastructure
         {
             // arrange
             const string value = "abc";
-            Func<string, string> selector = x => x.Substring(1);
+            string Selector(string x) => x.Substring(1);
 
             // act & assert
-            value.SafeGet(selector).Should().Be("bc");
+            value.SafeGet(Selector).Should().Be("bc");
         }
     }
 }

--- a/OAuth2.Tests/OAuth2.Tests.csproj
+++ b/OAuth2.Tests/OAuth2.Tests.csproj
@@ -19,4 +19,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/OAuth2/Client/IClient.cs
+++ b/OAuth2/Client/IClient.cs
@@ -30,23 +30,13 @@ namespace OAuth2.Client
         /// Returns URI of service which should be called in order to start authentication process. 
         /// You should use this URI when rendering login link.
         /// </summary>
-        string GetLoginLinkUri(string state = null);
+        Task<string> GetLoginLinkUriAsync(string state = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// State which was posted as additional parameter 
         /// to service and then received along with main answer.
         /// </summary>
         string State { get; }
-
-        /// <summary>
-        /// Obtains user information using third-party authentication service 
-        /// using data provided via callback request.
-        /// </summary>
-        /// <param name="parameters">
-        /// Callback request payload (parameters).
-        /// <example>Request.QueryString</example>
-        /// </param>
-        UserInfo GetUserInfo(NameValueCollection parameters);
 
         /// <summary>
         /// Obtains user information using third-party authentication service using data provided via callback request.

--- a/OAuth2/Client/IClient.cs
+++ b/OAuth2/Client/IClient.cs
@@ -1,4 +1,6 @@
 using System.Collections.Specialized;
+using System.Threading;
+using System.Threading.Tasks;
 using OAuth2.Configuration;
 using OAuth2.Models;
 
@@ -45,6 +47,15 @@ namespace OAuth2.Client
         /// <example>Request.QueryString</example>
         /// </param>
         UserInfo GetUserInfo(NameValueCollection parameters);
+
+        /// <summary>
+        /// Obtains user information using third-party authentication service using data provided via callback request.
+        /// </summary>
+        /// <param name="parameters">Callback request payload (parameters).</param>
+        /// <param name="cancellationToken">Optional cancellation token</param>
+        /// <returns></returns>
+        Task<UserInfo> GetUserInfoAsync(NameValueCollection parameters,
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Client configuration object.

--- a/OAuth2/Client/Impl/DigitalOceanClient.cs
+++ b/OAuth2/Client/Impl/DigitalOceanClient.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OAuth2.Configuration;
 using OAuth2.Infrastructure;
@@ -60,6 +62,12 @@ namespace OAuth2.Client.Impl
         protected override UserInfo GetUserInfo()
         {
             return ParseUserInfo(_accessToken);
+        }
+
+        /// <inheritdoc />
+        protected override Task<UserInfo> GetUserInfoAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(ParseUserInfo(_accessToken));
         }
 
         protected override UserInfo ParseUserInfo(string content)

--- a/OAuth2/Client/Impl/DigitalOceanClient.cs
+++ b/OAuth2/Client/Impl/DigitalOceanClient.cs
@@ -59,11 +59,6 @@ namespace OAuth2.Client.Impl
             }
         }
 
-        protected override UserInfo GetUserInfo()
-        {
-            return ParseUserInfo(_accessToken);
-        }
-
         /// <inheritdoc />
         protected override Task<UserInfo> GetUserInfoAsync(CancellationToken cancellationToken = default)
         {

--- a/OAuth2/Client/Impl/GitHubClient.cs
+++ b/OAuth2/Client/Impl/GitHubClient.cs
@@ -66,29 +66,6 @@ namespace OAuth2.Client.Impl
             return result;
         }
 
-        protected override UserInfo GetUserInfo() 
-        {
-            var userInfo = base.GetUserInfo();
-            if (userInfo == null)
-                return null;
-
-            if (!String.IsNullOrEmpty(userInfo.Email))
-                return userInfo;
-
-            var client = _factory.CreateClient(UserEmailServiceEndpoint);
-            client.Authenticator = new OAuth2UriQueryParameterAuthenticator(AccessToken);
-            var request = _factory.CreateRequest(UserEmailServiceEndpoint);
-
-            BeforeGetUserInfo(new BeforeAfterRequestArgs {
-                Client = client,
-                Request = request,
-                Configuration = Configuration
-            });
-
-            var response = client.ExecuteAndVerify(request);
-            return HandleUserInfoResponse(response, userInfo);
-        }
-
         protected override async Task<UserInfo> GetUserInfoAsync(CancellationToken cancellationToken = default)
         {
             var userInfo = await base.GetUserInfoAsync(cancellationToken).ConfigureAwait(false);
@@ -110,11 +87,6 @@ namespace OAuth2.Client.Impl
             });
 
             var response = await client.ExecuteAndVerifyAsync(request, cancellationToken).ConfigureAwait(false);
-            return HandleUserInfoResponse(response, userInfo);
-        }
-
-        UserInfo HandleUserInfoResponse(IRestResponse response, UserInfo userInfo)
-        {
             var userEmails = ParseEmailAddresses(response.Content).Where(u => !String.IsNullOrEmpty(u.Email)).ToList();
 
             string primaryEmail = userEmails.Where(u => u.Primary).Select(u => u.Email).FirstOrDefault();

--- a/OAuth2/Client/Impl/LinkedinClient.cs
+++ b/OAuth2/Client/Impl/LinkedinClient.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using OAuth2.Configuration;
 using OAuth2.Infrastructure;
 using OAuth2.Models;
@@ -68,9 +70,9 @@ namespace OAuth2.Client.Impl
             }
         }
 
-        public override string GetLoginLinkUri(string state = null)
+        public override Task<string> GetLoginLinkUriAsync(string state = null, CancellationToken cancellationToken = default)
         {
-            return base.GetLoginLinkUri(state ?? Guid.NewGuid().ToString("N"));
+            return base.GetLoginLinkUriAsync(state ?? Guid.NewGuid().ToString("N"), cancellationToken);
         }
 
         protected override void BeforeGetUserInfo(BeforeAfterRequestArgs args)

--- a/OAuth2/Client/OAuthClient.cs
+++ b/OAuth2/Client/OAuthClient.cs
@@ -63,33 +63,16 @@ namespace OAuth2.Client
         /// You should use this URI when rendering login link.
         /// </summary>
         /// <param name="state">Any additional information needed by application.</param>
+        /// <param name="cancellationToken">Optional cancellation token</param>
         /// <returns>Login link URI.</returns>
-        public string GetLoginLinkUri(string state = null)
+        public async Task<string> GetLoginLinkUriAsync(string state = null, CancellationToken cancellationToken = default)
         {
             if (!state.IsEmpty())
             {
                 throw new NotSupportedException("State transmission is not supported by current implementation.");
             }
-            QueryRequestToken();
+            await QueryRequestTokenAsync(cancellationToken).ConfigureAwait(false);
             return GetLoginRequestUri(state);
-        }
-
-        /// <summary>
-        /// Obtains user information using third-party authentication service
-        /// using data provided via callback request.
-        /// </summary>
-        /// <param name="parameters">Callback request payload (parameters).
-        /// <example>Request.QueryString</example></param>
-        /// <returns></returns>
-        public UserInfo GetUserInfo(NameValueCollection parameters)
-        {
-            AccessToken = parameters.GetOrThrowUnexpectedResponse(OAuthTokenKey);
-            QueryAccessToken(parameters.GetOrThrowUnexpectedResponse("oauth_verifier"));
-
-            var result = ParseUserInfo(QueryUserInfo());
-            result.ProviderName = Name;
-
-            return result;
         }
 
         /// <summary>
@@ -120,7 +103,8 @@ namespace OAuth2.Client
         /// <summary>
         /// Issues request for request token and returns result.
         /// </summary>
-        private void QueryRequestToken()
+        /// <param name="cancellationToken">Optional cancellation token</param>
+        private async Task QueryRequestTokenAsync(CancellationToken cancellationToken = default)
         {
             var client = _factory.CreateClient(RequestTokenServiceEndpoint);
             client.Authenticator = OAuth1Authenticator.ForRequestToken(
@@ -135,7 +119,7 @@ namespace OAuth2.Client
                 Configuration = Configuration
             });
 
-            var response = client.ExecuteAndVerify(request);
+            var response = await client.ExecuteAndVerifyAsync(request, cancellationToken).ConfigureAwait(false);
 
             AfterGetAccessToken(new BeforeAfterRequestArgs
             {
@@ -170,23 +154,6 @@ namespace OAuth2.Client
         /// Obtains access token by calling corresponding service.
         /// </summary>
         /// <param name="verifier">Verifier posted with callback issued by provider.</param>
-        /// <returns>Access token and other extra info.</returns>
-        private void QueryAccessToken(string verifier)
-        {
-            var client = _factory.CreateClient(AccessTokenServiceEndpoint);
-            client.Authenticator = OAuth1Authenticator.ForAccessToken(
-                Configuration.ClientId, Configuration.ClientSecret, AccessToken, AccessTokenSecret, verifier);
-
-            var request = _factory.CreateRequest(AccessTokenServiceEndpoint, Method.POST);
-
-            var response = client.ExecuteAndVerify(request);
-            HandleTokenResponse(response);
-        }
-
-        /// <summary>
-        /// Obtains access token by calling corresponding service.
-        /// </summary>
-        /// <param name="verifier">Verifier posted with callback issued by provider.</param>
         /// <param name="cancellationToken">Optional cancellation token</param>
         /// <returns>Access token and other extra info.</returns>
         private async Task QueryAccessTokenAsync(string verifier, CancellationToken cancellationToken = default)
@@ -198,11 +165,6 @@ namespace OAuth2.Client
             var request = _factory.CreateRequest(AccessTokenServiceEndpoint, Method.POST);
 
             var response = await client.ExecuteAndVerifyAsync(request, cancellationToken).ConfigureAwait(false);
-            HandleTokenResponse(response);
-        }
-
-        void HandleTokenResponse(IRestResponse response)
-        {
             var content = response.Content;
             var collection = HttpUtility.ParseQueryString(content);
 
@@ -233,7 +195,8 @@ namespace OAuth2.Client
         /// <summary>
         /// Queries user info using corresponding service and data received by access token request.
         /// </summary>
-        private string QueryUserInfo()
+        /// <param name="cancellationToken">Optional cancellationtoken</param>
+        private async Task<string> QueryUserInfoAsync(CancellationToken cancellationToken = default)
         {
             var client = _factory.CreateClient(UserInfoServiceEndpoint);
             client.Authenticator = OAuth1Authenticator.ForProtectedResource(
@@ -248,7 +211,8 @@ namespace OAuth2.Client
                 Configuration = Configuration
             });
 
-            return client.ExecuteAndVerify(request).Content;
+            var response = await client.ExecuteAndVerifyAsync(request, cancellationToken).ConfigureAwait(false);
+            return response.Content;
         }
 
         /// <inheritdoc />
@@ -257,7 +221,8 @@ namespace OAuth2.Client
             AccessToken = parameters.GetOrThrowUnexpectedResponse(OAuthTokenKey);
             await QueryAccessTokenAsync(parameters.GetOrThrowUnexpectedResponse("oauth_verifier"), cancellationToken).ConfigureAwait(false);
 
-            var result = ParseUserInfo(QueryUserInfo());
+            var userInfoResult = await QueryUserInfoAsync(cancellationToken).ConfigureAwait(false);
+            var result = ParseUserInfo(userInfoResult);
             result.ProviderName = Name;
 
             return result;

--- a/OAuth2/Infrastructure/RestClientExtensions.cs
+++ b/OAuth2/Infrastructure/RestClientExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading;
 using System.Threading.Tasks;
 using OAuth2.Client;
 using RestSharp;
@@ -9,13 +10,23 @@ namespace OAuth2.Infrastructure
     {
         public static IRestResponse ExecuteAndVerify(this IRestClient client, IRestRequest request)
         {
-            var response = client.Execute(request);
+            return VerifyResponse(client.Execute(request));
+        }
+
+        static IRestResponse VerifyResponse(IRestResponse response)
+        {
             if (response.Content.IsEmpty() ||
                 (response.StatusCode != HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Created))
             {
                 throw new UnexpectedResponseException(response);
             }
+
             return response;
+        }
+
+        public static async Task<IRestResponse> ExecuteAndVerifyAsync(this IRestClient client, IRestRequest request, CancellationToken cancellationToken = default)
+        {
+            return VerifyResponse(await client.ExecuteTaskAsync(request, cancellationToken).ConfigureAwait(false));
         }
     }
 }

--- a/OAuth2/Infrastructure/RestClientExtensions.cs
+++ b/OAuth2/Infrastructure/RestClientExtensions.cs
@@ -8,11 +8,6 @@ namespace OAuth2.Infrastructure
 {
     public static class RestClientExtensions
     {
-        public static IRestResponse ExecuteAndVerify(this IRestClient client, IRestRequest request)
-        {
-            return VerifyResponse(client.Execute(request));
-        }
-
         static IRestResponse VerifyResponse(IRestResponse response)
         {
             if (response.Content.IsEmpty() ||

--- a/OAuth2/Infrastructure/SafeExtensions.cs
+++ b/OAuth2/Infrastructure/SafeExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace OAuth2.Infrastructure
 {
@@ -13,6 +14,14 @@ namespace OAuth2.Infrastructure
         public static T SafeGet<TModel, T>(this TModel instance, Func<TModel, T> selector) where TModel : class
         {
             return instance == null ? default(T) : selector(instance);
+        }
+
+        /// <summary>
+        /// Executes selector on instance and returns result or returns default value of target type if given instance is null.
+        /// </summary>
+        public static async Task<T> SafeGetAsync<TModel, T>(this TModel instance, Func<TModel, Task<T>> selector) where TModel : class
+        {
+            return instance == null ? default(T) : await selector(instance);
         }
     }
 }


### PR DESCRIPTION
Fixes #53 

Right now I'm providing async alternatives for the existing methods, but because some of them are virtual, this means some code is duplicated. Should I remove the non-async methods?