### PR TITLE
Change GitHubClient to use Authorization header

### DIFF
--- a/OAuth2/Client/Impl/GitHubClient.cs
+++ b/OAuth2/Client/Impl/GitHubClient.cs
@@ -76,7 +76,7 @@ namespace OAuth2.Client.Impl
                 return userInfo;
 
             var client = _factory.CreateClient(UserEmailServiceEndpoint);
-            client.Authenticator = new OAuth2UriQueryParameterAuthenticator(AccessToken);
+            client.Authenticator = new OAuth2AuthorizationRequestHeaderAuthenticator(AccessToken, "token");
             var request = _factory.CreateRequest(UserEmailServiceEndpoint);
 
             BeforeGetUserInfo(new BeforeAfterRequestArgs


### PR DESCRIPTION
Fixes #135

Used `OAuth2AuthorizationRequestHeaderAuthenticator` instead as described https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/#changes-to-make