### PR TITLE
Allow OAuth2Client refresh token to be updated when grant_type is "refresh_token"

### DIFF
--- a/OAuth2.Tests/Client/OAuth2ClientTests.cs
+++ b/OAuth2.Tests/Client/OAuth2ClientTests.cs
@@ -13,6 +13,7 @@ using OAuth2.Models;
 using RestSharp;
 using FluentAssertions;
 using RestSharp.Authenticators;
+using Newtonsoft.Json;
 
 namespace OAuth2.Tests.Client
 {
@@ -175,6 +176,26 @@ namespace OAuth2.Tests.Client
             _restClient.Received(1).BaseUrl = new Uri("https://UserInfoServiceEndpoint");
             _restRequest.Received(1).Resource = "/UserInfoServiceEndpoint";
             _restClient.Authenticator.Should().BeOfType<OAuth2UriQueryParameterAuthenticator>();
+        }
+
+        [Test]
+        public async Task Should_Update_RefreshToken_When_GetCurrentTokenAsync_Used_For_Refresh()
+        {
+            // arrange
+            var refreshToken = "abc123";
+            var newRefreshToken = "xyz456";
+            var accessToken = "qwe789";
+            var response = JsonConvert.SerializeObject(new {
+                access_token = accessToken,
+                refresh_token = newRefreshToken
+            });
+            _restResponse.Content.Returns(response);
+
+            // act
+            await _descendant.GetCurrentTokenAsync(refreshToken);
+
+            // assert
+            Assert.That(_descendant.RefreshToken, Is.EqualTo(newRefreshToken));
         }
 
         class OAuth2ClientDescendant : OAuth2Client

--- a/OAuth2.Tests/Client/OAuth2ClientTests.cs
+++ b/OAuth2.Tests/Client/OAuth2ClientTests.cs
@@ -13,7 +13,6 @@ using OAuth2.Models;
 using RestSharp;
 using FluentAssertions;
 using RestSharp.Authenticators;
-using Newtonsoft.Json;
 
 namespace OAuth2.Tests.Client
 {
@@ -182,20 +181,29 @@ namespace OAuth2.Tests.Client
         public async Task Should_Update_RefreshToken_When_GetCurrentTokenAsync_Used_For_Refresh()
         {
             // arrange
-            var refreshToken = "abc123";
-            var newRefreshToken = "xyz456";
-            var accessToken = "qwe789";
-            var response = JsonConvert.SerializeObject(new {
-                access_token = accessToken,
-                refresh_token = newRefreshToken
-            });
+            var newRefreshToken = "new-refresh-token";
+            var response = @$"{{""access_token"": ""abc123"", ""refresh_token"": ""{newRefreshToken}""}}";
             _restResponse.Content.Returns(response);
 
             // act
-            await _descendant.GetCurrentTokenAsync(refreshToken);
+            await _descendant.GetCurrentTokenAsync("old-refresh-token");
 
             // assert
             Assert.That(_descendant.RefreshToken, Is.EqualTo(newRefreshToken));
+        }
+
+        [Test]
+        public async Task Should_Set_RefreshToken_To_Null_When_Not_Included_In_Response_From_GetCurrentTokenAsync()
+        {
+            // arrange
+            var response = @"{""access_token"": ""abc123""}";
+            _restResponse.Content.Returns(response);
+
+            // act
+            await _descendant.GetCurrentTokenAsync("refresh");
+
+            // assert
+            Assert.That(_descendant.RefreshToken, Is.Null);
         }
 
         class OAuth2ClientDescendant : OAuth2Client

--- a/OAuth2/Client/OAuth2Client.cs
+++ b/OAuth2/Client/OAuth2Client.cs
@@ -206,8 +206,7 @@ namespace OAuth2.Client
             if (String.IsNullOrEmpty(AccessToken))
                 throw new UnexpectedResponseException(AccessTokenKey);
 
-            if (GrantType != "refresh_token")
-                RefreshToken = ParseTokenResponse(response.Content, RefreshTokenKey);
+            RefreshToken = ParseTokenResponse(response.Content, RefreshTokenKey);
 
             TokenType = ParseTokenResponse(response.Content, TokenTypeKey);
 


### PR DESCRIPTION
Update the OAuth2 base client implementation so that the `RefreshToken` property is updated when refreshing access tokens (grant_type = "refresh_token"). Previously, the refresh token was only updated for requests where grant_type was not equal to "refresh_token".

This change is being made because many OAuth2 implementations will include an updated refresh token in the response to a "refresh_token" request. For the implementations that don't, the `RefreshToken` property will continue to be `null` after the response has been processed.