### PR TITLE
Include OAuth error code and description in UnexpectedResponseException

### DIFF
--- a/OAuth2.Tests/Client/OAuth2ClientTests.cs
+++ b/OAuth2.Tests/Client/OAuth2ClientTests.cs
@@ -110,13 +110,36 @@ namespace OAuth2.Tests.Client
         public async Task GetUserInfo_ErrorParameter_ThrowsUnexpectedResponse()
         {
             // arrange
-            var parameters = new NameValueCollection { { "error", "error2" } };
+            var parameters = new NameValueCollection { { "error", "access_denied" } };
 
             // act & assert
             var ex = await _descendant
                 .Awaiting(x => x.GetUserInfoAsync(parameters))
                 .Should().ThrowAsync<UnexpectedResponseException>();
             ex.And.FieldName.Should().Be("error");
+            ex.And.ErrorCode.Should().Be("access_denied");
+            ex.And.ErrorDescription.Should().BeNull();
+            ex.And.Message.Should().Contain("access_denied");
+        }
+
+        [Test]
+        public async Task GetUserInfo_ErrorWithDescription_ThrowsWithDetails()
+        {
+            // arrange
+            var parameters = new NameValueCollection
+            {
+                { "error", "access_denied" },
+                { "error_description", "The user denied the request." }
+            };
+
+            // act & assert
+            var ex = await _descendant
+                .Awaiting(x => x.GetUserInfoAsync(parameters))
+                .Should().ThrowAsync<UnexpectedResponseException>();
+            ex.And.ErrorCode.Should().Be("access_denied");
+            ex.And.ErrorDescription.Should().Be("The user denied the request.");
+            ex.And.Message.Should().Contain("access_denied");
+            ex.And.Message.Should().Contain("The user denied the request.");
         }
 
         [Test]

--- a/OAuth2/Client/OAuth2Client.cs
+++ b/OAuth2/Client/OAuth2Client.cs
@@ -178,7 +178,8 @@ namespace OAuth2.Client
             var error = parameters[errorFieldName];
             if (!error.IsEmpty())
             {
-                throw new UnexpectedResponseException(errorFieldName);
+                var errorDescription = parameters["error_description"];
+                throw new UnexpectedResponseException(errorFieldName, error, errorDescription);
             }
 
             State = parameters["state"];

--- a/OAuth2/Client/UnexpectedResponseException.cs
+++ b/OAuth2/Client/UnexpectedResponseException.cs
@@ -14,6 +14,18 @@ namespace OAuth2.Client
         public string? FieldName { get; set; }
 
         /// <summary>
+        /// OAuth error code returned by the provider (e.g. "access_denied", "invalid_request").
+        /// Populated when the error originates from an OAuth callback per RFC 6749 §4.1.2.1.
+        /// </summary>
+        public string? ErrorCode { get; set; }
+
+        /// <summary>
+        /// Human-readable error description returned by the provider.
+        /// Populated when the error originates from an OAuth callback per RFC 6749 §4.1.2.1.
+        /// </summary>
+        public string? ErrorDescription { get; set; }
+
+        /// <summary>
         /// Unexpected response itself (can be null, if error occurred later in the response processing pipeline).
         /// </summary>
         public RestResponse? Response { get; private set; }
@@ -23,6 +35,7 @@ namespace OAuth2.Client
         /// </summary>
         /// <param name="response">The response.</param>
         public UnexpectedResponseException(RestResponse response)
+            : base(BuildMessage(response))
         {
             Response = response;
         }
@@ -32,8 +45,38 @@ namespace OAuth2.Client
         /// </summary>
         /// <param name="fieldName">Name of the field.</param>
         public UnexpectedResponseException(string fieldName)
+            : base($"Unexpected value of '{fieldName}' received.")
         {
             FieldName = fieldName;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnexpectedResponseException"/> class
+        /// with OAuth error details from the provider callback.
+        /// </summary>
+        /// <param name="fieldName">Name of the field.</param>
+        /// <param name="errorCode">OAuth error code (e.g. "access_denied").</param>
+        /// <param name="errorDescription">Human-readable error description from the provider.</param>
+        public UnexpectedResponseException(string fieldName, string? errorCode, string? errorDescription)
+            : base(BuildMessage(fieldName, errorCode, errorDescription))
+        {
+            FieldName = fieldName;
+            ErrorCode = errorCode;
+            ErrorDescription = errorDescription;
+        }
+
+        private static string BuildMessage(RestResponse response)
+        {
+            return $"Unexpected response: {(int)response.StatusCode} {response.StatusDescription}";
+        }
+
+        private static string BuildMessage(string fieldName, string? errorCode, string? errorDescription)
+        {
+            if (!String.IsNullOrEmpty(errorDescription))
+                return $"OAuth error '{errorCode}': {errorDescription}";
+            if (!String.IsNullOrEmpty(errorCode))
+                return $"OAuth error '{errorCode}' received.";
+            return $"Unexpected value of '{fieldName}' received.";
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #75 

When a user cancels login or the provider denies access, the OAuth callback includes `error` and `error_description` parameters per [RFC 6749 §4.1.2.1](https://tools.ietf.org/html/rfc6749#section-4.1.2.1). Previously, `CheckErrorAndSetState` discarded the actual error values and only stored the field name `"error"` in the exception, making it impossible for callers to distinguish between different error types (e.g. `access_denied` vs `invalid_request` vs `server_error`).

## Changes

- **`UnexpectedResponseException`**: Added `ErrorCode` and `ErrorDescription` properties. Added a new constructor that accepts both values. All constructors now set a meaningful `Message`.
- **`OAuth2Client.CheckErrorAndSetState`**: Now reads `error_description` from the callback parameters and passes both the error code and description to the exception.
- **Tests**: Updated existing error test and added a new test verifying `error_description` is captured.

## Usage

Callers can now catch the exception and inspect the specific OAuth error:

```csharp
try
{
    var userInfo = await client.GetUserInfoAsync(parameters);
}
catch (UnexpectedResponseException ex) when (ex.ErrorCode == "access_denied")
{
    // User cancelled login - show friendly message
}
catch (UnexpectedResponseException ex)
{
    // Other OAuth error
    logger.Error("OAuth error {Code}: {Description}", ex.ErrorCode, ex.ErrorDescription);
}
```
